### PR TITLE
Add {rejectUnauthorized :boolean} to ssl type

### DIFF
--- a/src/postgres-options.ts
+++ b/src/postgres-options.ts
@@ -15,7 +15,7 @@ export interface PostgresOptions<T> extends TransportStreamOptions {
     /**
      * Ssl active
      */
-    ssl?: boolean;
+    ssl?: {rejectUnauthorized :boolean } | boolean;
 
     /**
      * Schema of the database

--- a/src/postgres-options.ts
+++ b/src/postgres-options.ts
@@ -15,7 +15,7 @@ export interface PostgresOptions<T> extends TransportStreamOptions {
     /**
      * Ssl active
      */
-    ssl?: {rejectUnauthorized :boolean } | boolean;
+    ssl?: { rejectUnauthorized: boolean } | boolean;
 
     /**
      * Schema of the database


### PR DESCRIPTION
The current interface for `PostgresOptions` does not support everything.
This PR updates the `ssl` property to support an object, e,g, ` {rejectUnauthorized :boolean }`